### PR TITLE
DCAC-151: Changes made to facilitate testing of resilience in Tilt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.8</ch-kafka.version>
         <mockito.version>4.8.0</mockito.version>
         <spring-boot-dependencies.version>2.7.8</spring-boot-dependencies.version>
-        <private-api-sdk-java.version>2.0.254</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.280</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
 
         <start-class>uk.gov.companieshouse.documentsigningrequestconsumer.DocumentSigningRequestConsumerApplication</start-class>

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.documentsigningrequestconsumer;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
@@ -7,10 +8,11 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 @Component
 public class ApiClientService {
 
+    @Value("${internal.api.url}") String internalApiUrl;
+
     public InternalApiClient getInternalApiClient() {
         final var client = ApiSdkManager.getPrivateSDK();
-        // TODO DCAC-151 Replace this Tilt-specific override with an environment variable.
-        client.setInternalBasePath(client.getBasePath());
+        client.setInternalBasePath(internalApiUrl);
         return client;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientService.java
@@ -8,7 +8,11 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 @Component
 public class ApiClientService {
 
-    @Value("${internal.api.url}") String internalApiUrl;
+    private final String internalApiUrl;
+
+    public ApiClientService(@Value("${internal.api.url}") String internalApiUrl) {
+        this.internalApiUrl = internalApiUrl;
+    }
 
     public InternalApiClient getInternalApiClient() {
         final var client = ApiSdkManager.getPrivateSDK();

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientService.java
@@ -4,12 +4,13 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
-import java.io.IOException;
-
 @Component
 public class ApiClientService {
 
     public InternalApiClient getInternalApiClient() {
-        return ApiSdkManager.getPrivateSDK();
+        final var client = ApiSdkManager.getPrivateSDK();
+        // TODO DCAC-151 Replace this Tilt-specific override with an environment variable.
+        client.setInternalBasePath(client.getBasePath());
+        return client;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/DocumentSigningService.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/DocumentSigningService.java
@@ -75,7 +75,7 @@ class DocumentSigningService implements Service {
             //TODO Use response to populate satisfy item request
 
         } catch (ApiErrorResponseException e) {
-            logger.error("Failed to get response from Document Signing API: " + e, getLogMap(orderId, itemGroupId, e));
+            logger.error("Got error response from Document Signing API: " + e, getLogMap(orderId, itemGroupId, e));
             throw new RetryableException("Attempting retry due to failed response", e);
         } catch (URIValidationException e) {
             logger.error("Error with URI: " + e, getLogMap(orderId, itemGroupId, e));

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/EnvironmentVariablesChecker.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/EnvironmentVariablesChecker.java
@@ -21,7 +21,11 @@ public class EnvironmentVariablesChecker {
         MAX_ATTEMPTS("MAX_ATTEMPTS"),
         DOCUMENT_SIGNING_REQUEST_CONSUMER_PORT("DOCUMENT_SIGNING_REQUEST_CONSUMER_PORT"),
         TOPIC("TOPIC"),
-        PREFIX("PREFIX");
+        PREFIX("PREFIX"),
+        API_URL("API_URL"),
+        PAYMENTS_API_URL("PAYMENTS_API_URL"),
+        CHS_API_KEY("CHS_API_KEY"),
+        INTERNAL_API_URL("INTERNAL_API_URL");
 
         private final String name;
 

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientServiceTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.documentsigningrequestconsumer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApiClientServiceTest {
+
+    private static final String CONFIGURED_INTERNAL_API_URL = "http://api.chs.local:4001";
+
+    @InjectMocks
+    private ApiClientService service;
+
+    @Mock
+    private InternalApiClient client;
+
+    @Test
+    @DisplayName("getInternalApiClient returns internal API client with an overridden internal API URL value")
+    void getInternalApiClientOverridesInternalApiUrlUsed() {
+
+        service.internalApiUrl = CONFIGURED_INTERNAL_API_URL;
+
+        try (final MockedStatic<ApiSdkManager> sdkManager = Mockito.mockStatic(ApiSdkManager.class)) {
+            sdkManager.when(ApiSdkManager::getPrivateSDK).thenReturn(client);
+
+            service.getInternalApiClient();
+
+            verify(client).setInternalBasePath(CONFIGURED_INTERNAL_API_URL);
+        }
+
+    }
+
+
+}

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/ApiClientServiceTest.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.documentsigningrequestconsumer;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -18,17 +18,19 @@ class ApiClientServiceTest {
 
     private static final String CONFIGURED_INTERNAL_API_URL = "http://api.chs.local:4001";
 
-    @InjectMocks
     private ApiClientService service;
 
     @Mock
     private InternalApiClient client;
 
+    @BeforeEach
+    void setUp() {
+        service = new ApiClientService(CONFIGURED_INTERNAL_API_URL);
+    }
+
     @Test
     @DisplayName("getInternalApiClient returns internal API client with an overridden internal API URL value")
     void getInternalApiClientOverridesInternalApiUrlUsed() {
-
-        service.internalApiUrl = CONFIGURED_INTERNAL_API_URL;
 
         try (final MockedStatic<ApiSdkManager> sdkManager = Mockito.mockStatic(ApiSdkManager.class)) {
             sdkManager.when(ApiSdkManager::getPrivateSDK).thenReturn(client);

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/EnvironmentVariablesCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/EnvironmentVariablesCheckerTest.java
@@ -19,13 +19,17 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.BACKOFF_DELAY;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.BOOTSTRAP_SERVER_URL;
+import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.CHS_API_KEY;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.CONCURRENT_LISTENER_INSTANCES;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.DOCUMENT_SIGNING_REQUEST_CONSUMER_PORT;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.GROUP_ID;
+import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.INTERNAL_API_URL;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.INVALID_MESSAGE_TOPIC;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.MAX_ATTEMPTS;
+import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.PAYMENTS_API_URL;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.PREFIX;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.TOPIC;
+import static uk.gov.companieshouse.documentsigningrequestconsumer.EnvironmentVariablesChecker.RequiredEnvironmentVariables.API_URL;
 
 @SpringBootTest
 @TestPropertySource(locations = "classpath:application-test_main_positive.yml")
@@ -104,6 +108,29 @@ class EnvironmentVariablesCheckerTest {
         populateAllVariablesExceptOneAndAssertSomethingMissing(TOPIC);
     }
 
+    @DisplayName("returns false if API_URL is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfApiUrlMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(API_URL);
+    }
+
+    @DisplayName("returns false if PAYMENTS_API_URL is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfPaymentsApiUrlMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(PAYMENTS_API_URL);
+    }
+
+    @DisplayName("returns false if CHS_API_KEY is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfChsApiKeyMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(CHS_API_KEY);
+    }
+
+    @DisplayName("returns false if INTERNAL_API_URL is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfInternalApiUrlMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(INTERNAL_API_URL);
+    }
 
     @DisplayName("returns false if PREFIX is missing")
     @Test

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/SignDigitalDocumentInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/SignDigitalDocumentInTiltProducer.java
@@ -11,6 +11,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static uk.gov.companieshouse.documentsigningrequestconsumer.Constants.DOCUMENT;
 import static uk.gov.companieshouse.documentsigningrequestconsumer.Constants.SAME_PARTITION_KEY;
@@ -27,7 +33,10 @@ import static uk.gov.companieshouse.documentsigningrequestconsumer.Constants.SAM
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class SignDigitalDocumentInTiltProducer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger("SignDigitalDocumentInTiltProducer");
+    private static final String SIGN_DIGITAL_DOCUMENT_TOPIC = "sign-digital-document";
     private static final String KAFKA_IN_TILT_BOOTSTRAP_SERVER_URL = "localhost:29092";
+    private static final int MESSAGE_WAIT_TIMEOUT_SECONDS = 10;
 
     @Rule
     private static final EnvironmentVariables ENVIRONMENT_VARIABLES;
@@ -38,7 +47,7 @@ class SignDigitalDocumentInTiltProducer {
         ENVIRONMENT_VARIABLES.set("BACKOFF_DELAY", "100");
         ENVIRONMENT_VARIABLES.set("BOOTSTRAP_SERVER_URL", KAFKA_IN_TILT_BOOTSTRAP_SERVER_URL);
         ENVIRONMENT_VARIABLES.set("CONCURRENT_LISTENER_INSTANCES", "1");
-        ENVIRONMENT_VARIABLES.set("TOPIC", "sign-digital-document");
+        ENVIRONMENT_VARIABLES.set("TOPIC", SIGN_DIGITAL_DOCUMENT_TOPIC);
         ENVIRONMENT_VARIABLES.set("INVALID_MESSAGE_TOPIC", "sign-digital-document-invalid");
         ENVIRONMENT_VARIABLES.set("GROUP_ID","document-signing-request-consumer");
     }
@@ -48,8 +57,13 @@ class SignDigitalDocumentInTiltProducer {
 
     @SuppressWarnings("squid:S2699") // at least one assertion
     @Test
-    void produceMessageToTilt() {
-        testProducer.send(new ProducerRecord<>(
-                "sign-digital-document", 0, System.currentTimeMillis(), SAME_PARTITION_KEY, DOCUMENT));
+    void produceMessageToTilt() throws InterruptedException, ExecutionException, TimeoutException {
+        final var future = testProducer.send(new ProducerRecord<>(
+                SIGN_DIGITAL_DOCUMENT_TOPIC, 0, System.currentTimeMillis(), SAME_PARTITION_KEY, DOCUMENT));
+        final var result = future.get(MESSAGE_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        final var partition = result.partition();
+        final var offset = result.offset();
+        LOGGER.info("Message " + DOCUMENT + " delivered to topic " + SIGN_DIGITAL_DOCUMENT_TOPIC
+                + " on partition " + partition + " with offset " + offset + ".");
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,4 +19,5 @@ invalid_message_topic=${INVALID_MESSAGE_TOPIC}
 
 logger.namespace=document-signing-request-consumer
 
-internal.api.url=${INTERNAL_API_URL}
+internal.api.url=token value
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,23 +1,2 @@
-# Actuator health check config
-management.endpoints.web.base-path=/
-management.endpoints.web.path-mapping.health=healthcheck
-
-# Default application root path
-server.servlet.context-path=/document-signing-request-consumer
-
-server.port=${DOCUMENT_SIGNING_REQUEST_CONSUMER_PORT}
-
-spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER_URL}
-
-consumer.topic=${TOPIC}
-consumer.group_id=${GROUP_ID}
-consumer.max_attempts=${MAX_ATTEMPTS}
-consumer.backoff_delay=${BACKOFF_DELAY}
-consumer.concurrency=${CONCURRENT_LISTENER_INSTANCES}
-
-invalid_message_topic=${INVALID_MESSAGE_TOPIC}
-
-logger.namespace=document-signing-request-consumer
-
 internal.api.url=token value
 

--- a/src/test/resources/sign-digital-document-in-tilt.properties
+++ b/src/test/resources/sign-digital-document-in-tilt.properties
@@ -1,0 +1,10 @@
+spring.kafka.bootstrap-servers=localhost:29092
+consumer.topic=sign-digital-document
+consumer.group_id=document-signing-request-consumer
+consumer.max_attempts=4
+consumer.backoff_delay=100
+consumer.concurrency=1
+invalid_message_topic=sign-digital-document-invalid
+
+logger.namespace=document-signing-request-consumer
+steps: 1


### PR DESCRIPTION
* Found that in Tilt at least, could not test the resilient consumption of `sign-digital-document` messages by the `document-signing-request-consumer` because it would error upon trying to send the sign PDF request to the `document-signing-api`. To be able to move on to the testing of resilience in Tilt, the following changes have been made:
    * Logging of error messages improved so underlying causes of failures can be seen when the app tries to send the sign PDF requests.
    * The default base path value provided by the SDK for internal API calls is overridden within the app itself. It overrides this with the value provided in the `INTERNAL_API_URL` environment variable, so that when working with the app in environments other than `live`, the requests do not always get sent to the `live` version of the `document-signing-api`.
    * Checks have been added for the presence of the extra environment variables required to be able to configure the sign PDF request sending client correctly for each environment. 
* See [related PR](https://github.com/companieshouse/docker-chs-development/pull/773).
 