### PR TITLE
dcac-289 amendment to build satisfy-item uri.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/satisfyitem/SatisfyItemApiPatch.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/satisfyitem/SatisfyItemApiPatch.java
@@ -36,7 +36,6 @@ public class SatisfyItemApiPatch {
 //        final String itemGroupsUri = parameters.getData().getGroupItem() + parameters.getData().getItemId();
         final String itemGroupsUri = getGroupItemExcludingItemId(parameters.getData().getGroupItem())
             + parameters.getData().getItemId();
-        System.out.printf("\nitemGroupsUri = [%s]\n", itemGroupsUri);
 
         final Status documentStatus = (status == HttpStatus.CREATED.value()) ? Status.SATISFIED : Status.FAILED;
         final SatisfyItemApi satisfyItemApi = new SatisfyItemApi(documentStatus.toString(), documentLocation);

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/satisfyitem/SatisfyItemApiPatch.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/satisfyitem/SatisfyItemApiPatch.java
@@ -33,7 +33,6 @@ public class SatisfyItemApiPatch {
     public void satisfyItem(ServiceParameters parameters, int status, String documentLocation)
         throws ApiErrorResponseException, URIValidationException {
 
-//        final String itemGroupsUri = parameters.getData().getGroupItem() + parameters.getData().getItemId();
         final String itemGroupsUri = getGroupItemExcludingItemId(parameters.getData().getGroupItem())
             + parameters.getData().getItemId();
 

--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/satisfyitem/SatisfyItemApiPatch.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/satisfyitem/SatisfyItemApiPatch.java
@@ -33,7 +33,11 @@ public class SatisfyItemApiPatch {
     public void satisfyItem(ServiceParameters parameters, int status, String documentLocation)
         throws ApiErrorResponseException, URIValidationException {
 
-        final String itemGroupsUri = parameters.getData().getGroupItem() + parameters.getData().getItemId();
+//        final String itemGroupsUri = parameters.getData().getGroupItem() + parameters.getData().getItemId();
+        final String itemGroupsUri = getGroupItemExcludingItemId(parameters.getData().getGroupItem())
+            + parameters.getData().getItemId();
+        System.out.printf("\nitemGroupsUri = [%s]\n", itemGroupsUri);
+
         final Status documentStatus = (status == HttpStatus.CREATED.value()) ? Status.SATISFIED : Status.FAILED;
         final SatisfyItemApi satisfyItemApi = new SatisfyItemApi(documentStatus.toString(), documentLocation);
         //
@@ -47,5 +51,17 @@ public class SatisfyItemApiPatch {
 
         logger.info("API returned response: "+ response.getStatusCode(),
             getLogMap(parameters.getData().get(ORDER_ID).toString(), parameters.getData().get(GROUP_ITEM).toString()));
+    }
+
+    private String getGroupItemExcludingItemId (final String groupItem)
+    {
+        String groupItemExcludingItemId = "";
+        int lastIndex = 0;
+
+        if ((lastIndex = groupItem.lastIndexOf('/')) != -1) {
+            groupItemExcludingItemId = groupItem.substring(0, lastIndex + 1);
+        }
+
+        return groupItemExcludingItemId;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/Constants.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
             .setOrderNumber("CCD-123456-123456")
             .setPrivateS3Location("s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf")
             .setDocumentType("363s")
-            .setGroupItem("/item-groups/IG-123456-123456/items/")
+            .setGroupItem("/item-groups/IG-123456-123456/items/CCD-123456-123456")
             .setItemId("CCD-123456-123456")
             .setFilingHistoryDescriptionValues(FILING_HISTORY_DESCRIPTION_VALUES)
             .build();


### PR DESCRIPTION
item-group-workflow-api uses self link for item group when building message for kafka topic item-ordered-certified-copy.
This change uses both group item and item id so strips appended item id from group item.