### PR TITLE
increasing CPU and memory for cidev profile

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -3,6 +3,8 @@ aws_profile = "development-eu-west-2"
 
 # service configs
 use_set_environment_files = true
+required_cpus = 512
+required_memory = 1024
 
 # Scheduled scaling of tasks
 service_autoscale_enabled  = true


### PR DESCRIPTION
Increasing the CPU and memory for cidev profile to see if this assists with the issue we have with deployment. Task is recycling and was healthy but still shutting down. 
