### PR TITLE
Feature/cc 3410

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,10 @@ spring:
 
   kafka:
     bootstrap-servers: ${BOOTSTRAP_SERVER_URL}
+    listener:
+      observation-enabled: true
+    template:
+      observation-enabled: true
 
 consumer:
   topic: ${TOPIC}
@@ -35,6 +39,12 @@ management:
       export:
         otlp:
           endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces
+      sampler:
+        otel:
+          sampler:
+            jaeger:
+              remote:
+                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
   otlp:
     metrics:
       export:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,12 +39,6 @@ management:
       export:
         otlp:
           endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces
-      sampler:
-        otel:
-          sampler:
-            jaeger:
-              remote:
-                endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
   otlp:
     metrics:
       export:


### PR DESCRIPTION
enabling observation so Spring will wrap the raw Kafka span name and provide parent/child nesting, so X-Ray knows:
Parent: "document-signing-request-consumer" (service span)
Child: "cidev-sign-digital-document process" (Kafka message processing)
Grandchild: API call spans