### PR TITLE
feature/CC-3410: overriding spam name

### DIFF
--- a/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/telemetry/KafkaSpanNameProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/documentsigningrequestconsumer/telemetry/KafkaSpanNameProcessor.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.documentsigningrequestconsumer.telemetry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Custom {@link SpanProcessor} that renames Kafka consumer spans to use the service name
+ * instead of the topic name. This ensures the AWS X-Ray trace map displays the correct
+ * service name rather than the Kafka topic name as the node label.
+ *
+ * <p>The OpenTelemetry Kafka instrumentation generates span names in the format
+ * {@code {topic} {operation}} (e.g. {@code cidev-sign-digital-document process}), which
+ * the ADOT collector uses as the X-Ray segment {@code name} field — the label shown in
+ * the trace map. This processor overrides that with the application service name.</p>
+ */
+@Component
+public class KafkaSpanNameProcessor implements SpanProcessor {
+
+    private static final AttributeKey<String> MESSAGING_SYSTEM_KEY =
+            AttributeKey.stringKey("messaging.system");
+
+    private final String serviceName;
+
+    public KafkaSpanNameProcessor(
+            @Value("${spring.application.name:document-signing-request-consumer}") String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
+    public void onStart(final Context parentContext, final ReadWriteSpan span) {
+        if ("kafka".equals(span.getAttribute(MESSAGING_SYSTEM_KEY))) {
+            span.updateName(serviceName);
+        }
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return true;
+    }
+
+    @Override
+    public void onEnd(final ReadableSpan span) {
+        // no-op
+    }
+
+    @Override
+    public boolean isEndRequired() {
+        return false;
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/telemetry/KafkaSpanNameProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/telemetry/KafkaSpanNameProcessorTest.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.documentsigningrequestconsumer.telemetry;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,20 +72,17 @@ class KafkaSpanNameProcessorTest {
 
     @Test
     void isStartRequired_returnsTrue() {
-        // Then
-        assert underTest.isStartRequired();
+        assertTrue(underTest.isStartRequired());
     }
 
     @Test
     void isEndRequired_returnsFalse() {
-        // Then
-        assert !underTest.isEndRequired();
+        assertFalse(underTest.isEndRequired());
     }
 
     @Test
     void onEnd_doesNothing() {
-        // When / Then (no exception thrown, no interactions)
-        underTest.onEnd(readableSpan);
+        assertDoesNotThrow(() -> underTest.onEnd(readableSpan));
     }
 }
 

--- a/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/telemetry/KafkaSpanNameProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/documentsigningrequestconsumer/telemetry/KafkaSpanNameProcessorTest.java
@@ -1,0 +1,88 @@
+package uk.gov.companieshouse.documentsigningrequestconsumer.telemetry;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaSpanNameProcessorTest {
+
+    private static final String SERVICE_NAME = "document-signing-request-consumer";
+    private static final AttributeKey<String> MESSAGING_SYSTEM_KEY =
+            AttributeKey.stringKey("messaging.system");
+
+    private final KafkaSpanNameProcessor underTest = new KafkaSpanNameProcessor(SERVICE_NAME);
+
+    @Mock
+    ReadWriteSpan span;
+
+    @Mock
+    ReadableSpan readableSpan;
+
+    @Mock
+    Context context;
+
+    @Test
+    void givenKafkaSpan_whenOnStart_thenSpanRenamedToServiceName() {
+        // Given
+        when(span.getAttribute(MESSAGING_SYSTEM_KEY)).thenReturn("kafka");
+
+        // When
+        underTest.onStart(context, span);
+
+        // Then
+        verify(span).updateName(SERVICE_NAME);
+    }
+
+    @Test
+    void givenNonKafkaSpan_whenOnStart_thenSpanNameNotChanged() {
+        // Given
+        when(span.getAttribute(MESSAGING_SYSTEM_KEY)).thenReturn("http");
+
+        // When
+        underTest.onStart(context, span);
+
+        // Then
+        verify(span, never()).updateName(SERVICE_NAME);
+    }
+
+    @Test
+    void givenSpanWithNoMessagingSystem_whenOnStart_thenSpanNameNotChanged() {
+        // Given
+        when(span.getAttribute(MESSAGING_SYSTEM_KEY)).thenReturn(null);
+
+        // When
+        underTest.onStart(context, span);
+
+        // Then
+        verify(span, never()).updateName(SERVICE_NAME);
+    }
+
+    @Test
+    void isStartRequired_returnsTrue() {
+        // Then
+        assert underTest.isStartRequired();
+    }
+
+    @Test
+    void isEndRequired_returnsFalse() {
+        // Then
+        assert !underTest.isEndRequired();
+    }
+
+    @Test
+    void onEnd_doesNothing() {
+        // When / Then (no exception thrown, no interactions)
+        underTest.onEnd(readableSpan);
+    }
+}
+


### PR DESCRIPTION
creating a processor to override the spam name.  The OpenTelemetry Kafka instrumentation generates span names in the format {{topic} {operation}} (e.g. cidev-sign-digital-document process), which the ADOT collector uses as the X-Ray segment field — the label shown in the trace map. This processor overrides that with the application service name.